### PR TITLE
Adds new line delimiter at end of each packet.

### DIFF
--- a/lib/syslog_protocol/packet.rb
+++ b/lib/syslog_protocol/packet.rb
@@ -7,7 +7,7 @@ module SyslogProtocol
       assemble
     end
 
-    def assemble(max_size = 1024)
+    def assemble(max_size = 1023)
       unless @hostname and @facility and @severity and @tag
         raise "Could not assemble packet without hostname, tag, facility, and severity"
       end
@@ -20,7 +20,7 @@ module SyslogProtocol
         end
       end
 
-      data
+      "#{data}\n"
     end
 
     def facility=(f)

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -15,14 +15,14 @@ describe "syslog logger" do
     p = @logger.instance_variable_get("@packet")
     p.time = Time.now
     ts = p.generate_timestamp
-    @logger.debug("vacuum tubez are operational").should.equal "<135>#{ts} space_station test: vacuum tubez are operational"
-    @logger.info("firing thrusters at 13 degrees").should.equal "<134>#{ts} space_station test: firing thrusters at 13 degrees"
-    @logger.notice("the hyper drive has been activated").should.equal "<133>#{ts} space_station test: the hyper drive has been activated"
-    @logger.warn("meteorites incoming!").should.equal "<132>#{ts} space_station test: meteorites incoming!"
-    @logger.err("vacuum tube 3 in hyper drive failed").should.equal "<131>#{ts} space_station test: vacuum tube 3 in hyper drive failed"
-    @logger.crit("wing struck by a meteorite!").should.equal "<130>#{ts} space_station test: wing struck by a meteorite!"
-    @logger.alert("LEAKING ATMOSPHERE").should.equal "<129>#{ts} space_station test: LEAKING ATMOSPHERE"
-    @logger.emerg("LEAKING ASTRONAUTS WE ARE DONE").should.equal "<128>#{ts} space_station test: LEAKING ASTRONAUTS WE ARE DONE"
+    @logger.debug("vacuum tubez are operational").should.equal "<135>#{ts} space_station test: vacuum tubez are operational\n"
+    @logger.info("firing thrusters at 13 degrees").should.equal "<134>#{ts} space_station test: firing thrusters at 13 degrees\n"
+    @logger.notice("the hyper drive has been activated").should.equal "<133>#{ts} space_station test: the hyper drive has been activated\n"
+    @logger.warn("meteorites incoming!").should.equal "<132>#{ts} space_station test: meteorites incoming!\n"
+    @logger.err("vacuum tube 3 in hyper drive failed").should.equal "<131>#{ts} space_station test: vacuum tube 3 in hyper drive failed\n"
+    @logger.crit("wing struck by a meteorite!").should.equal "<130>#{ts} space_station test: wing struck by a meteorite!\n"
+    @logger.alert("LEAKING ATMOSPHERE").should.equal "<129>#{ts} space_station test: LEAKING ATMOSPHERE\n"
+    @logger.emerg("LEAKING ASTRONAUTS WE ARE DONE").should.equal "<128>#{ts} space_station test: LEAKING ASTRONAUTS WE ARE DONE\n"
   end
 
 end

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -81,7 +81,7 @@ describe "a syslog packet" do
 
   it "use the current time and assemble the packet" do
     timestamp = @p.generate_timestamp
-    @p.to_s.should.equal "<165>#{timestamp} space_station test: exploring ze black hole"
+    @p.to_s.should.equal "<165>#{timestamp} space_station test: exploring ze black hole\n"
   end
 
   it "packets larger than 1024 will be truncated" do


### PR DESCRIPTION
I'm making this change to, hopefully, improve compatibility with syslog collectors that are looking for a delimiter between messages. Of note, I was having trouble using Heka as a remote syslog collector with the remote_syslog_logger gem (which relies on syslog_protocol) because Heka was expecting a new line character to mark the end of a message.
