### PR TITLE
Support GLOG Severity levels

### DIFF
--- a/lib/syslog_protocol/common.rb
+++ b/lib/syslog_protocol/common.rb
@@ -1,6 +1,6 @@
 module SyslogProtocol
   # These hashes stolen from Syslog.pm
-  
+
   FACILITIES = {
     'kern'     => 0,
     'user'     => 1,
@@ -27,7 +27,7 @@ module SyslogProtocol
     'local6'   => 22,
     'local7'   => 23
   }
-  
+
   FACILITY_INDEX = {
     0   => 'kern',
     1   => 'user',
@@ -54,7 +54,7 @@ module SyslogProtocol
     22  => 'local6',
     23  => 'local7'
   }
-  
+
   SEVERITIES = {
     'emerg'   => 0,
     'alert'   => 1,
@@ -63,9 +63,13 @@ module SyslogProtocol
     'warn'    => 4,
     'notice'  => 5,
     'info'    => 6,
-    'debug'   => 7 
+    'debug'   => 7,
+    'I'       => 6,
+    'W'       => 4,
+    'E'       => 3,
+    'F'       => 0
   }
-  
+
   SEVERITY_INDEX = {
     0  => 'emerg',
     1  => 'alert',


### PR DESCRIPTION
* Based on https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog.go#L108

I get errors of unknown severity levels when using fleuntd with syslog output (similar to [1] but forwarding to syslog instead to elastic search)
```
2017-11-28 12:37:53 +0000 [warn]: emit transaction failed: error_class=ArgumentError error="'I' is not a designated severity" tag="kube-proxy"
  2017-11-28 12:37:53 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/syslog_protocol-0.9.2/lib/syslog_protocol/packet.rb:72:in `severity='
  2017-11-28 12:37:53 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/remote_syslog_logger-1.0.3/lib/remote_syslog_logger/udp_sender.rb:19:in `initialize'
  2017-11-28 12:37:53 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-remote_syslog-0.3.3/lib/fluent/plugin/out_remote_syslog.rb:44:in `new'
  2017-11-28 12:37:53 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-remote_syslog-0.3.3/lib/fluent/plugin/out_remote_syslog.rb:44:in `block in emit'
```

[1] https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml